### PR TITLE
Codacy-inspired changes to the Trace handling in integration tests

### DIFF
--- a/core/src/test/scala/com/github/simbo1905/trex/internals/TestPaxosActor.scala
+++ b/core/src/test/scala/com/github/simbo1905/trex/internals/TestPaxosActor.scala
@@ -2,6 +2,7 @@ package com.github.simbo1905.trex.internals
 
 import akka.actor.ActorRef
 import com.github.simbo1905.trex._
+import com.github.simbo1905.trex.internals.PaxosActor.TraceData
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -22,10 +23,10 @@ class TestPaxosActor(config: PaxosActor.Configuration, nodeUniqueId: Int, broadc
   }
 
   override def trace(state: PaxosRole, data: PaxosData, sender: ActorRef, msg: Any): Unit = {
-    if (tracer.isDefined) tracer.get(nodeUniqueId, state, data, sender, msg)
+    tracer.foreach(t => t(TraceData(nodeUniqueId, state, data, Some(sender), msg)))
   }
 
   override def trace(state: PaxosRole, data: PaxosData, payload: CommandValue): Unit = {
-    if (tracer.isDefined) tracer.get(nodeUniqueId, state, data, null, payload)
+    tracer.foreach(t => t(TraceData(nodeUniqueId, state, data, None, payload)))
   }
 }


### PR DESCRIPTION
I’ve changed the `var Halt` in ClusterHarness to a case object,
triggered by a Codacy message. That led me to do a bit more re-working
around tracing, namely passing the TraceData a case class rather than a
Tuple.
